### PR TITLE
Fix activation URL parameter mismatch

### DIFF
--- a/accounts/urls.py
+++ b/accounts/urls.py
@@ -7,6 +7,6 @@ urlpatterns = [
     path('register/', register, name='register'),
     path('login/', CustomLoginView.as_view(), name='login'),
     path('logout/', LogoutView.as_view(), name='logout'),
-    path('activate/<uid>/<token>/', activate, name='activate'),
+    path('activate/<uidb64>/<token>/', activate, name='activate'),
     path('profile/', profile, name='profile'),
 ]


### PR DESCRIPTION
## Summary
- ensure the activation URL uses `uidb64` to match the view

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python manage.py check` *(fails: ImportError: Couldn't import Django)*

------
https://chatgpt.com/codex/tasks/task_e_685288412b44832dadee68ca106056ea