### PR TITLE
Fix admin fields for new short descriptions

### DIFF
--- a/main/admin.py
+++ b/main/admin.py
@@ -5,15 +5,15 @@ from .models import TarotCard, ReadingHistory
 class TarotCardAdmin(admin.ModelAdmin):
     list_display = ('name', 'arcana', 'suit', 'number')
     list_filter = ('arcana', 'suit')
-    search_fields = ('name', 'description', 'full_description')
+    search_fields = ('name', 'short_description', 'full_description')
     fields = (
         'name',
         'arcana',
         'suit',
         'number',
-        'description',
+        'short_description',
         'full_description',
-        'reversed_description',
+        'short_description_reversed',
         'full_description_reversed',
         'image',
     )


### PR DESCRIPTION
## Summary
- update TarotCard admin to refer to `short_description` fields

## Testing
- `python manage.py check`

------
https://chatgpt.com/codex/tasks/task_e_6852899c6bb8832da616371d1f47fe22