### PR TITLE
Fix activation link

### DIFF
--- a/accounts/templates/accounts/account_activation_email.html
+++ b/accounts/templates/accounts/account_activation_email.html
@@ -2,6 +2,6 @@
 
 Щоб активувати свій обліковий запис на MyArcana.online, перейдіть за цим посиланням:
 
-http://{{ domain }}{% url 'activate' uid=uid token=token %}
+http://{{ domain }}{% url 'activate' uidb64=uidb64 token=token %}
 
 Якщо ви не реєструвались на нашому сайті — просто ігноруйте цей лист.

--- a/accounts/views.py
+++ b/accounts/views.py
@@ -24,7 +24,7 @@ def register(request):
             message = render_to_string('accounts/account_activation_email.html', {
                 'user': user,
                 'domain': current_site.domain,
-                'uid': urlsafe_base64_encode(force_bytes(user.pk)),
+                'uidb64': urlsafe_base64_encode(force_bytes(user.pk)),
                 'token': account_activation_token.make_token(user),
             })
             email = EmailMessage(mail_subject, message, to=[user.email])


### PR DESCRIPTION
## Summary
- fix link in activation email to use uidb64

## Testing
- `python manage.py check`
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_685293085c4c832d9f26b5f3f32107df